### PR TITLE
Downgrade flake8 to v5 and reintroduce it

### DIFF
--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -1,4 +1,4 @@
-flake8
+flake8<6.0
 mypy
 pylint
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     -r{toxinidir}/requirements.testing.txt
     -r{toxinidir}/requirements.txt
 commands =
-    # flake8 ytclip_server  # busted, todo fix.
+    flake8 ytclip_server
     pylint ytclip_server
     mypy ytclip_server
     # NOTE: you can run any command line tool here - not just tests


### PR DESCRIPTION
v6 of flake8 must have a bug, as it breaks when checking the repo.